### PR TITLE
Fix 404 errors on pages

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -1,0 +1,3 @@
+
+# Redirect all routes to index.html for client-side routing
+/* /index.html 200


### PR DESCRIPTION
Addresses 404 errors encountered on the conditions générales and mentions légales pages when deployed with Netlify.